### PR TITLE
Repro Object BindingContainer Bug

### DIFF
--- a/samples/android-app/build.gradle.kts
+++ b/samples/android-app/build.gradle.kts
@@ -24,6 +24,10 @@ android {
   }
 }
 
+metro {
+  debug = true
+}
+
 dependencies {
   implementation(libs.androidx.appcompat)
   implementation(libs.androidx.core)

--- a/samples/android-app/src/main/kotlin/dev/zacsweers/metro/sample/android/AppGraph.kt
+++ b/samples/android-app/src/main/kotlin/dev/zacsweers/metro/sample/android/AppGraph.kt
@@ -8,10 +8,13 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkManager
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Multibinds
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
+import kotlin.random.Random
 import kotlin.reflect.KClass
 
 @DependencyGraph(AppScope::class)
@@ -42,4 +45,12 @@ interface AppGraph {
   fun interface Factory {
     fun create(@Provides application: Application): AppGraph
   }
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+object TestContainer {
+
+  @Provides
+  fun providesDouble(): Double = Random.nextDouble()
 }


### PR DESCRIPTION
```
com.android.tools.r8.internal.Jf: Illegal class file: Interface dev/zacsweers/metro/sample/android/TestContainer$$$MetroContributionToAppScope must extend class java.lang.Object. Found: dev/zacsweers/metro/sample/android/TestContainer. Class file version 55.
```